### PR TITLE
Open correct dashboard when notification about active device is clicked

### DIFF
--- a/ansible/roles/home-assistant/defaults/main/dashboards.yml
+++ b/ansible/roles/home-assistant/defaults/main/dashboards.yml
@@ -1,16 +1,18 @@
 dashboards:
-
-  - id: dashboard-light
+  light:
     title: Oświetlenie
     icon: mdi:lightbulb
     filename: light.yaml
+    url: dashboard-light
 
-  - id: dashboard-blind
+  blind:
     title: Rolety
     icon: mdi:blinds
     filename: blinds.yaml
+    url: dashboard-blind
 
-  - id: dashboard-management
+  management:
     title: Zarządzanie
     icon: mdi:home-outline
     filename: management.yaml
+    url: dashboard-management

--- a/ansible/roles/home-assistant/defaults/main/light.yml
+++ b/ansible/roles/home-assistant/defaults/main/light.yml
@@ -27,6 +27,7 @@ light_switches:
         name: Dolna łazienka górne światło
         night_brightness_pct: 27
         notify_when_on_from: "00:30:00"
+        url_to_open: "/{{ dashboards.light.url }}/downstairs"
 
   - device_id: "downstairs_bathroom_mirror_light_switch"
     friendly_name: Dolna łazienka oświetlenie lustra
@@ -43,6 +44,7 @@ light_switches:
         name: Dolna łazienka oświetlenie lustra
         night_brightness_pct: 29
         notify_when_on_from: "00:30:00"
+        url_to_open: "/{{ dashboards.light.url }}/downstairs"
 
   - device_id: "living_room_light_switch"
     friendly_name: Salon światło
@@ -98,6 +100,7 @@ light_switches:
         suffix:
         name: Spiżarnia światło
         notify_when_on_from: "00:15:00"
+        url_to_open: "/{{ dashboards.light.url }}/downstairs"
 
   - device_id: "kitchen_main_light_switch"
     friendly_name: Kuchnia górne światło
@@ -139,10 +142,12 @@ light_switches:
         suffix: _l1
         name: Wiatrołap górne światło
         notify_when_on_from: "00:10:00"
+        url_to_open: "/{{ dashboards.light.url }}/downstairs"
       - id: L2
         suffix: _l2
         name: Wiatrołap oświetlenie szafek
         notify_when_on_from: "00:10:00"
+        url_to_open: "/{{ dashboards.light.url }}/downstairs"
 
   - device_id: "mudroom_auxiliary_light_switch"
     friendly_name: Wiatrołap - przycisk pomocniczy
@@ -165,10 +170,12 @@ light_switches:
         suffix: _l1
         name: Garaż światło przy kotłowni
         notify_when_on_from: "02:00:00"
+        url_to_open: "/{{ dashboards.light.url }}/downstairs"
       - id: L2
         suffix: _l2
         name: Garaż światło przy wiatrołapie
         notify_when_on_from: "02:00:00"
+        url_to_open: "/{{ dashboards.light.url }}/downstairs"
 
   - device_id: "boiler_room_light_switch"
     friendly_name: Kotłownia światło
@@ -184,6 +191,7 @@ light_switches:
         suffix: _l2
         name: Kotłownia światło
         notify_when_on_from: "00:15:00"
+        url_to_open: "/{{ dashboards.light.url }}/downstairs"
 
   - device_id: "staircase_light_switch"
     friendly_name: Światło na schodach
@@ -205,6 +213,7 @@ light_switches:
         suffix:
         name: Światło w pralni
         notify_when_on_from: "00:20:00"
+        url_to_open: "/{{ dashboards.light.url }}/upstairs"
 
   - device_id: "upstairs_bathroom_main_light_switch"
     friendly_name: Górna łazienka światło górne
@@ -216,11 +225,13 @@ light_switches:
         suffix: _l1
         name: Górna łazienka światło górne
         notify_when_on_from: "01:00:00"
+        url_to_open: "/{{ dashboards.light.url }}/upstairs"
       - id: L2
         suffix: _l2
         name: Górna łazienka LED pod prysznicem
         dimmable: false
         notify_when_on_from: "01:00:00"
+        url_to_open: "/{{ dashboards.light.url }}/upstairs"
 
   - device_id: "upstairs_bathroom_left_mirror_light_switch"
     friendly_name: Górna łazienka światło przy lewym lustrze
@@ -232,10 +243,12 @@ light_switches:
         suffix: _l1
         name: Górna łazienka światło przy lewym lustrze górne
         notify_when_on_from: "01:00:00"
+        url_to_open: "/{{ dashboards.light.url }}/upstairs"
       - id: L2
         suffix: _l2
         name: Górna łazienka światło przy lewym lustrze LED
         notify_when_on_from: "00:15:00"
+        url_to_open: "/{{ dashboards.light.url }}/upstairs"
 
   - device_id: "upstairs_bathroom_right_mirror_light_switch"
     friendly_name: Górna łazienka światło przy prawym lustrze
@@ -247,10 +260,12 @@ light_switches:
         suffix: _l1
         name: Górna łazienka światło przy prawym lustrze LED
         notify_when_on_from: "00:15:00"
+        url_to_open: "/{{ dashboards.light.url }}/upstairs"
       - id: L2
         suffix: _l2
         name: Górna łazienka światło przy prawym lustrze górne
         notify_when_on_from: "00:15:00"
+        url_to_open: "/{{ dashboards.light.url }}/upstairs"
 
   - device_id: "upstairs_bathroom_washbasin_cabinet_backlight"
     friendly_name: Górna łazienka podświetlenie szafki z umywalkami
@@ -263,6 +278,7 @@ light_switches:
         name: Górna łazienka podświetlenie szafki z umywalkami
         night_brightness_pct: 2
         notify_when_on_from: "01:00:00"
+        url_to_open: "/{{ dashboards.light.url }}/upstairs"
 
   - device_id: "guest_room_light_switch"
     friendly_name: Światło w gościnnym
@@ -284,6 +300,7 @@ light_switches:
         suffix:
         name: Światło w schowku
         notify_when_on_from: "00:05:00"
+        url_to_open: "/{{ dashboards.light.url }}/upstairs"
 
   - device_id: "master_bedroom_main_light_switch"
     friendly_name: Główne światło w głównej sypialni
@@ -335,10 +352,12 @@ light_switches:
         suffix: _l1
         name: Podświetlenie LED w garderobie
         notify_when_on_from: "00:10:00"
+        url_to_open: "/{{ dashboards.light.url }}/upstairs"
       - id: L2
         suffix: _l2
         name: Górne światło w garderobie
         notify_when_on_from: "00:10:00"
+        url_to_open: "/{{ dashboards.light.url }}/upstairs"
 
   - device_id: "west_bedroom_light_switch"
     friendly_name: Światło w zachodniej sypialni
@@ -396,6 +415,7 @@ light_switches:
         suffix:
         name: Podświetlenie listew w korytarzu
         notify_when_on_from: "00:05:00"
+        url_to_open: "/{{ dashboards.light.url }}/upstairs"
 
   - device_id: "attic_light_switch"
     friendly_name: Światło na strychu
@@ -407,6 +427,7 @@ light_switches:
         suffix:
         name: Światło na strychu
         notify_when_on_from: "00:15:00"
+        url_to_open: "/{{ dashboards.light.url }}/attic"
 
   - device_id: "front_door_light_switch"
     friendly_name: Światło przed drzwiami wejściowymi
@@ -418,6 +439,7 @@ light_switches:
         suffix:
         name: Światło przed drzwiami wejściowymi
         notify_when_on_from: "00:15:00"
+        url_to_open: "/{{ dashboards.light.url }}/outdoors"
 
   - device_id: "side_door_light_switch"
     friendly_name: Światło przed drzwiami bocznymi
@@ -429,6 +451,7 @@ light_switches:
         suffix:
         name: Światło przed drzwiami bocznymi
         notify_when_on_from: "00:15:00"
+        url_to_open: "/{{ dashboards.light.url }}/outdoors"
 
   - device_id: "upstairs_terrace_light_switch"
     friendly_name: Światło na górnym tarasie
@@ -440,10 +463,12 @@ light_switches:
         suffix: _l1
         name: Światło na górnym tarasie - lewe
         notify_when_on_from: "00:15:00"
+        url_to_open: "/{{ dashboards.light.url }}/outdoors"
       - id: L2
         suffix: _l2
         name: Światło na górnym tarasie - prawe
         notify_when_on_from: "00:15:00"
+        url_to_open: "/{{ dashboards.light.url }}/outdoors"
 
   - device_id: "drive_light_switch"
     friendly_name: Światło na podjeździe
@@ -455,6 +480,7 @@ light_switches:
         suffix:
         name: Światło na podjeździe
         notify_when_on_from: "00:15:00"
+        url_to_open: "/{{ dashboards.light.url }}/outdoors"
 
 temporary_lights:
   - id: garage_temporary_light

--- a/ansible/roles/home-assistant/files/blueprints/automations/entity_on_notifier.yaml
+++ b/ansible/roles/home-assistant/files/blueprints/automations/entity_on_notifier.yaml
@@ -14,6 +14,10 @@ blueprint:
       name: Time spent in on state
       selector:
         duration:
+    url_to_open:
+      name: URL to be opened
+      selector:
+        text:
 
 mode: restart
 max_exceeded: silent
@@ -26,6 +30,7 @@ trigger:
 action:
   - variables:
       entity_name: !input entity_name
+      url_to_open: !input url_to_open
   - wait_for_trigger:
       - trigger: state
         entity_id: !input entity_id
@@ -41,3 +46,5 @@ action:
         data:
           message: "{{ entity_name }}"
           title: "Sprawdź urządzenie"
+          data:
+            clickAction: "{{ url_to_open }}"

--- a/ansible/roles/home-assistant/templates/automations/entity_on_notifier.yaml.j2
+++ b/ansible/roles/home-assistant/templates/automations/entity_on_notifier.yaml.j2
@@ -8,6 +8,7 @@
       entity_id: light.{{ light.device_id }}{{ part.suffix }}
       entity_name: {{ part.name }}
       in_state_time: {{ part.notify_when_on_from }}
+      url_to_open: {{ part.url_to_open }}
 {% endfor %}
 {% endfor %}
 
@@ -20,4 +21,5 @@
       entity_id: binary_sensor.{{ entity.name }}
       entity_name: {{ entity.friendly_name }}
       in_state_time: {{ entity.notify_when_active_from }}
+      url_to_open: {{ entity.url_to_open }}
 {% endfor %}

--- a/ansible/roles/home-assistant/templates/dashboards.yaml.j2
+++ b/ansible/roles/home-assistant/templates/dashboards.yaml.j2
@@ -1,6 +1,6 @@
-{%- for dashboard in dashboards %}
+{%- for key, dashboard in dashboards.items() %}
 
-{{ dashboard.id }}:
+{{ dashboard.url }}:
   mode: yaml
   title: {{ dashboard.title }}
   icon: {{ dashboard.icon }}

--- a/ansible/roles/home-assistant/templates/dashboards/blinds.yaml.j2
+++ b/ansible/roles/home-assistant/templates/dashboards/blinds.yaml.j2
@@ -2,6 +2,7 @@ views:
 {%- for floor in floors if floor.has_blinds %}
 
   - title: {{ floor.friendly_name }}
+    path: {{ floor.id }}
     cards:
       - type: entities
         entities:

--- a/ansible/roles/home-assistant/templates/dashboards/light.yaml.j2
+++ b/ansible/roles/home-assistant/templates/dashboards/light.yaml.j2
@@ -2,6 +2,7 @@ views:
 {%- for floor in floors if floor.has_lights %}
 
   - title: {{ floor.friendly_name }}
+    path: {{ floor.id }}
     cards:
       - type: entities
         entities:


### PR DESCRIPTION
It works also for garage gate and entrance gate thanks to changes in satel.yml:
`url_to_open: "/{{ dashboards.management.url }}/0"` needs to be added for `garage_gate_magnetic_sensor` and `entrance_gate_magnetic_sensor`